### PR TITLE
넷플릭스 기술블로그 링크 수정 요청

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ https://developer.apple.com
 
 NETFLIX
 
-https://brunch.co.kr/@sicle-official/35
+https://netflixtechblog.com
 
 GOOGLE
 


### PR DESCRIPTION
작성해주신 부분 중, 넷플릭스 기술블로그 링크로 들어가면 해당 블로그가 아닌, `기술블로그 링크를 모아둔 블로그 포스팅`으로 접속됩니다. 
이 점을 수정한 PR을 조심스레 날려봅니다 😄 