### PR TITLE
fix: 쿠팡 기술블로그 링크 수정 요청

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://medium.com/daangn
 
 쿠팡
 
-https://medium.com/coupang-tech/technote/home
+https://medium.com/coupang-engineering/kr/home
 
 마켓컬리
 


### PR DESCRIPTION
현재, 쿠팡 기술블로그 링크가 잘못돼있습니다. (들어가면 404가 뜹니다.)
올바른 쿠팡 엔지니어링 기술블로그 링크로 수정했습니다. 